### PR TITLE
escape " for description string

### DIFF
--- a/commands.go
+++ b/commands.go
@@ -36,7 +36,9 @@ func (c *Commands) List(cli *cli.Context) {
 		for _, p := range *ps.Packages {
 			fmt.Printf("(name \"%s\" version \"%s\" ", p.Name, p.Version)
 			if showDesc {
-				fmt.Printf("description \"%s\"", TrimNewLine(p.Description))
+				str := strings.Replace(p.Description, "'", "\\'", -1)
+				str = strings.Replace(str, "\"", "\\\"", -1)
+				fmt.Printf("description \"%s\"", TrimNewLine(str))
 			}
 			fmt.Print(")")
 		}


### PR DESCRIPTION
I used to use emacs. i tried to use cdnjs.el to insert url. but i found error. 
it is caused by gocdnjs program. 

"cdnjs l -p" 

This program generates lisp string to be parsed by emacs. but it is not valid on emacs.

so i fixed it. 
